### PR TITLE
Simplification of locate_synapses arguments, minor refactors

### DIFF
--- a/skeleton_synapses/default_run.sh
+++ b/skeleton_synapses/default_run.sh
@@ -4,8 +4,7 @@ cred_path="credentials_real.json"
 stack_id=1
 skel_id=11524047
 
-./locate_synapses.py ${cred_path} ${stack_id} ${skel_id} ${project_dir}/projects/full-vol-autocontext.ilp \
-${project_dir}/projects/multicut/L1-CNS-multicut.ilp ${project_dir}/skeletons;
+./locate_synapses.py ${cred_path} ${stack_id} ${skel_id} ${project_dir};
 
 ./results_to_volume.py ${cred_path} ${stack_id} ${skel_id} ${project_dir}/skeletons \
 ${project_dir}/synapse_volume.hdf5;

--- a/skeleton_synapses/dev_run.sh
+++ b/skeleton_synapses/dev_run.sh
@@ -4,8 +4,7 @@ cred_path="credentials_dev.json"
 stack_id=1
 skel_id=11524047
 
-./locate_synapses.py ${cred_path} ${stack_id} ${skel_id} ${project_dir}/projects/full-vol-autocontext.ilp \
-${project_dir}/projects/multicut/L1-CNS-multicut.ilp ${project_dir}/skeletons;
+./locate_synapses.py ${cred_path} ${stack_id} ${skel_id} ${project_dir};
 
 ./results_to_volume.py ${cred_path} ${stack_id} ${skel_id} ${project_dir}/skeletons \
 ${project_dir}/synapse_volume.hdf5;


### PR DESCRIPTION
- Given that the ilp files' relative locations are hardcoded, there doesn't seem to be any point referring to them separately, so now it takes the general project directory (i.e. `path/to/projects-2017/L1-CNS`) and works the rest out for itself.
- All references to L1-CNS have been replaced with a reference to a constant at the top of the file, or portability.
- L1-CNS-description-NO-OFFSET.json is now generated in its required place with its required title.
- Minor refactors and documentation in `catmaid_interface`
- Added skeleton_id back into the output CSV, as it's useful to know which skeleton 'overlaps_node_segment' refers to.